### PR TITLE
Elligantt - randomizing encoding alternative to NTT 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 name = "ml-kem"
 version = "0.1.1"
 dependencies = [
+ "cfg-if",
  "criterion",
  "crypto-common",
  "hex",

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -19,6 +19,7 @@ default = ["std", "elligantt"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
 elligantt = [] # Expose randomizing encapsulation key encoding and decoding functions
+debug = []
 
 [dependencies]
 kem = "0.3.0-pre.0"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 
 [features]
-default = ["std", "elligantt"]
+default = ["std", "kemeleon"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
-elligantt = [] # Expose randomizing encapsulation key encoding and decoding functions
+kemeleon = [] # Expose randomizing encapsulation key encoding and decoding functions
 debug = []
 
 [dependencies]

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -18,12 +18,14 @@ keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 default = ["std"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
+elligantt = [] # Expose randomizing encapsulation key encoding and decoding functions
 
 [dependencies]
 kem = "0.3.0-pre.0"
 hybrid-array = { version = "0.2.0-rc.8", features = ["extra-sizes"] }
 rand_core = "0.6.4"
 sha3 = { version = "0.10.8", default-features = false }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 default = ["std", "kemeleon"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
-kemeleon = [] # Expose randomizing encapsulation key encoding and decoding functions
+kemeleon = ["dep:num-bigint"] # Expose randomizing encapsulation key encoding and decoding functions
 debug = []
 
 [dependencies]
@@ -27,6 +27,7 @@ hybrid-array = { version = "0.2.0-rc.8", features = ["extra-sizes"] }
 rand_core = "0.6.4"
 sha3 = { version = "0.10.8", default-features = false }
 cfg-if = "1.0.0"
+num-bigint = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ml-kem/Cargo.toml
+++ b/ml-kem/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "kyber", "lattice", "post-quantum"]
 
 [features]
-default = ["std"]
+default = ["std", "elligantt"]
 std = ["sha3/std"]
 deterministic = [] # Expose deterministic generation and encapsulation functions
 elligantt = [] # Expose randomizing encapsulation key encoding and decoding functions

--- a/ml-kem/src/elligantt.rs
+++ b/ml-kem/src/elligantt.rs
@@ -1,0 +1,307 @@
+use hybrid_array::{
+    typenum::{Unsigned, U256},
+    Array,
+};
+
+use crate::algebra::{
+    FieldElement, Integer, NttPolynomial, NttVector, Polynomial, PolynomialVector,
+};
+use crate::param::{ArraySize, EncodedPolynomial, EncodingSize, VectorEncodingSize};
+use crate::util::Truncate;
+
+type DecodedValue = Array<FieldElement, U256>;
+
+// Algorithm 4 ByteEncode_d(F)
+//
+// Note: This algorithm performs compression as well as encoding.
+fn byte_encode<D: EncodingSize>(vals: &DecodedValue) -> EncodedPolynomial<D> {
+    let val_step = D::ValueStep::USIZE;
+    let byte_step = D::ByteStep::USIZE;
+
+    let mut bytes = EncodedPolynomial::<D>::default();
+
+    let vc = vals.chunks(val_step);
+    let bc = bytes.chunks_mut(byte_step);
+    for (v, b) in vc.zip(bc) {
+        let mut x = 0u128;
+        for (j, vj) in v.iter().enumerate() {
+            x |= u128::from(vj.0) << (D::USIZE * j);
+        }
+
+        let xb = x.to_le_bytes();
+        b.copy_from_slice(&xb[..byte_step]);
+    }
+
+    bytes
+}
+
+// Algorithm 5 ByteDecode_d(F)
+//
+// Note: This function performs decompression as well as decoding.
+fn byte_decode<D: EncodingSize>(bytes: &EncodedPolynomial<D>) -> DecodedValue {
+    let val_step = D::ValueStep::USIZE;
+    let byte_step = D::ByteStep::USIZE;
+    let mask = (1 << D::USIZE) - 1;
+
+    let mut vals = DecodedValue::default();
+
+    let vc = vals.chunks_mut(val_step);
+    let bc = bytes.chunks(byte_step);
+    for (v, b) in vc.zip(bc) {
+        let mut xb = [0u8; 16];
+        xb[..byte_step].copy_from_slice(b);
+
+        let x = u128::from_le_bytes(xb);
+        for (j, vj) in v.iter_mut().enumerate() {
+            let val: Integer = (x >> (D::USIZE * j)).truncate();
+            vj.0 = val & mask;
+
+            if D::USIZE == 12 {
+                vj.0 %= FieldElement::Q;
+            }
+        }
+    }
+
+    vals
+}
+
+pub trait Encode<D: EncodingSize> {
+    type EncodedSize: ArraySize;
+    fn encode(&self) -> Array<u8, Self::EncodedSize>;
+    fn decode(enc: &Array<u8, Self::EncodedSize>) -> Self;
+}
+
+impl<D: EncodingSize> Encode<D> for Polynomial {
+    type EncodedSize = D::EncodedPolynomialSize;
+
+    fn encode(&self) -> Array<u8, Self::EncodedSize> {
+        byte_encode::<D>(&self.0)
+    }
+
+    fn decode(enc: &Array<u8, Self::EncodedSize>) -> Self {
+        Self(byte_decode::<D>(enc))
+    }
+}
+
+impl<D, K> Encode<D> for PolynomialVector<K>
+where
+    K: ArraySize,
+    D: VectorEncodingSize<K>,
+{
+    type EncodedSize = D::EncodedPolynomialVectorSize;
+
+    fn encode(&self) -> Array<u8, Self::EncodedSize> {
+        let polys = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+        <D as VectorEncodingSize<K>>::flatten(polys)
+    }
+
+    fn decode(enc: &Array<u8, Self::EncodedSize>) -> Self {
+        let unfold = <D as VectorEncodingSize<K>>::unflatten(enc);
+        Self(
+            unfold
+                .iter()
+                .map(|&x| <Polynomial as Encode<D>>::decode(x))
+                .collect(),
+        )
+    }
+}
+
+impl<D: EncodingSize> Encode<D> for NttPolynomial {
+    type EncodedSize = D::EncodedPolynomialSize;
+
+    fn encode(&self) -> Array<u8, Self::EncodedSize> {
+        byte_encode::<D>(&self.0)
+    }
+
+    fn decode(enc: &Array<u8, Self::EncodedSize>) -> Self {
+        Self(byte_decode::<D>(enc))
+    }
+}
+
+impl<D, K> Encode<D> for NttVector<K>
+where
+    D: VectorEncodingSize<K>,
+    K: ArraySize,
+{
+    type EncodedSize = D::EncodedPolynomialVectorSize;
+
+    fn encode(&self) -> Array<u8, Self::EncodedSize> {
+        let polys = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+        <D as VectorEncodingSize<K>>::flatten(polys)
+    }
+
+    fn decode(enc: &Array<u8, Self::EncodedSize>) -> Self {
+        let unfold = <D as VectorEncodingSize<K>>::unflatten(enc);
+        Self(
+            unfold
+                .iter()
+                .map(|&x| <NttPolynomial as Encode<D>>::decode(x))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use core::fmt::Debug;
+    use core::ops::Rem;
+    use hybrid_array::typenum::{
+        marker_traits::Zero, operator_aliases::Mod, U1, U10, U11, U12, U2, U3, U4, U5, U6, U8,
+    };
+    use rand::Rng;
+
+    use crate::param::EncodedPolynomialVector;
+
+    // A helper trait to construct larger arrays by repeating smaller ones
+    trait Repeat<T: Clone, D: ArraySize> {
+        fn repeat(&self) -> Array<T, D>;
+    }
+
+    impl<T, N, D> Repeat<T, D> for Array<T, N>
+    where
+        N: ArraySize,
+        T: Clone,
+        D: ArraySize + Rem<N>,
+        Mod<D, N>: Zero,
+    {
+        #[allow(clippy::integer_division_remainder_used)]
+        fn repeat(&self) -> Array<T, D> {
+            Array::from_fn(|i| self[i % N::USIZE].clone())
+        }
+    }
+
+    #[allow(clippy::integer_division_remainder_used)]
+    fn byte_codec_test<D>(decoded: DecodedValue, encoded: EncodedPolynomial<D>)
+    where
+        D: EncodingSize,
+    {
+        // Test known answer
+        let actual_encoded = byte_encode::<D>(&decoded);
+        assert_eq!(actual_encoded, encoded);
+
+        let actual_decoded = byte_decode::<D>(&encoded);
+        assert_eq!(actual_decoded, decoded);
+
+        // Test random decode/encode and encode/decode round trips
+        let mut rng = rand::thread_rng();
+        let mut decoded: Array<Integer, U256> = Default::default();
+        rng.fill(decoded.as_mut_slice());
+        let m = match D::USIZE {
+            12 => FieldElement::Q,
+            d => (1 as Integer) << d,
+        };
+        let decoded = decoded.iter().map(|x| FieldElement(x % m)).collect();
+
+        let actual_encoded = byte_encode::<D>(&decoded);
+        let actual_decoded = byte_decode::<D>(&actual_encoded);
+        assert_eq!(actual_decoded, decoded);
+
+        let actual_reencoded = byte_encode::<D>(&decoded);
+        assert_eq!(actual_reencoded, actual_encoded);
+    }
+
+    #[test]
+    fn byte_codec() {
+        // The 1-bit can only represent decoded values equal to 0 or 1.
+        let decoded: DecodedValue = Array::<_, U2>([FieldElement(0), FieldElement(1)]).repeat();
+        let encoded: EncodedPolynomial<U1> = Array([0xaa; 32]);
+        byte_codec_test::<U1>(decoded, encoded);
+
+        // For other codec widths, we use a standard sequence
+        let decoded: DecodedValue = Array::<_, U8>([
+            FieldElement(0),
+            FieldElement(1),
+            FieldElement(2),
+            FieldElement(3),
+            FieldElement(4),
+            FieldElement(5),
+            FieldElement(6),
+            FieldElement(7),
+        ])
+        .repeat();
+
+        let encoded: EncodedPolynomial<U4> = Array::<_, U4>([0x10, 0x32, 0x54, 0x76]).repeat();
+        byte_codec_test::<U4>(decoded, encoded);
+
+        let encoded: EncodedPolynomial<U5> =
+            Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
+        byte_codec_test::<U5>(decoded, encoded);
+
+        let encoded: EncodedPolynomial<U6> =
+            Array::<_, U6>([0x40, 0x20, 0x0c, 0x44, 0x61, 0x1c]).repeat();
+        byte_codec_test::<U6>(decoded, encoded);
+
+        let encoded: EncodedPolynomial<U10> =
+            Array::<_, U10>([0x00, 0x04, 0x20, 0xc0, 0x00, 0x04, 0x14, 0x60, 0xc0, 0x01]).repeat();
+        byte_codec_test::<U10>(decoded, encoded);
+
+        let encoded: EncodedPolynomial<U11> = Array::<_, U11>([
+            0x00, 0x08, 0x80, 0x00, 0x06, 0x40, 0x80, 0x02, 0x18, 0xe0, 0x00,
+        ])
+        .repeat();
+        byte_codec_test::<U11>(decoded, encoded);
+
+        let encoded: EncodedPolynomial<U12> = Array::<_, U12>([
+            0x00, 0x10, 0x00, 0x02, 0x30, 0x00, 0x04, 0x50, 0x00, 0x06, 0x70, 0x00,
+        ])
+        .repeat();
+        byte_codec_test::<U12>(decoded, encoded);
+    }
+
+    #[allow(clippy::integer_division_remainder_used)]
+    #[test]
+    fn byte_codec_12_mod() {
+        // DecodeBytes_12 is required to reduce mod q
+        let encoded: EncodedPolynomial<U12> = Array([0xff; 384]);
+        let decoded: DecodedValue = Array([FieldElement(0xfff % FieldElement::Q); 256]);
+
+        let actual_decoded = byte_decode::<U12>(&encoded);
+        assert_eq!(actual_decoded, decoded);
+    }
+
+    fn vector_codec_known_answer_test<D, T>(decoded: T, encoded: Array<u8, T::EncodedSize>)
+    where
+        D: EncodingSize,
+        T: Encode<D> + PartialEq + Debug,
+    {
+        let actual_encoded = decoded.encode();
+        assert_eq!(actual_encoded, encoded);
+
+        let actual_decoded: T = Encode::decode(&encoded);
+        assert_eq!(actual_decoded, decoded);
+    }
+
+    #[test]
+    fn vector_codec() {
+        let poly = Polynomial(
+            Array::<_, U8>([
+                FieldElement(0),
+                FieldElement(1),
+                FieldElement(2),
+                FieldElement(3),
+                FieldElement(4),
+                FieldElement(5),
+                FieldElement(6),
+                FieldElement(7),
+            ])
+            .repeat(),
+        );
+
+        // The required vector sizes are 2, 3, and 4.
+        let decoded: PolynomialVector<U2> = PolynomialVector(Array([poly, poly]));
+        let encoded: EncodedPolynomialVector<U5, U2> =
+            Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
+        vector_codec_known_answer_test::<U5, PolynomialVector<U2>>(decoded, encoded);
+
+        let decoded: PolynomialVector<U3> = PolynomialVector(Array([poly, poly, poly]));
+        let encoded: EncodedPolynomialVector<U5, U3> =
+            Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
+        vector_codec_known_answer_test::<U5, PolynomialVector<U3>>(decoded, encoded);
+
+        let decoded: PolynomialVector<U4> = PolynomialVector(Array([poly, poly, poly, poly]));
+        let encoded: EncodedPolynomialVector<U5, U4> =
+            Array::<_, U5>([0x20, 0x88, 0x41, 0x8a, 0x39]).repeat();
+        vector_codec_known_answer_test::<U5, PolynomialVector<U4>>(decoded, encoded);
+    }
+}

--- a/ml-kem/src/elligantt.rs
+++ b/ml-kem/src/elligantt.rs
@@ -1,3 +1,18 @@
+//!
+//! The public key the pair A and t. It is encoded as NTT(t) || rho, where rho is the seed for A.
+//!   - rho is obviously random.
+//!   - NTT(t) is indistinguishable from a random vector… but these values are
+//!     all modulo q, so you can recognize a Kyber public key because its values
+//!     are all below q.
+
+//! This can be fixed by encoding NTT(t) differently. This module implements
+//! one such alternate encoding / decoding scheme.
+//!
+//! This has two practical uses, (1) making public keys sent over the wire
+//! indistinguishable from random bytes, and (2) streamlining the process of
+//! implementating the `hash2curve` interface for ml-kem.
+//!
+
 use hybrid_array::{
     typenum::{Unsigned, U256},
     Array,

--- a/ml-kem/src/elligantt.rs
+++ b/ml-kem/src/elligantt.rs
@@ -109,7 +109,9 @@ where
     type EncodedSize = D::EncodedPolynomialVectorSize;
 
     fn encode(&self) -> Array<u8, Self::EncodedSize> {
-        let polys = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+        let polys: Array<EncodedPolynomial<D>, K> = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+        #[cfg(feature = "debug")]
+        polys.iter().for_each(|x| println!("{x:?}"));
         <D as VectorEncodingSize<K>>::flatten(polys)
     }
 

--- a/ml-kem/src/elligantt.rs
+++ b/ml-kem/src/elligantt.rs
@@ -24,6 +24,9 @@ use crate::algebra::{
 use crate::param::{ArraySize, EncodedPolynomial, EncodingSize, VectorEncodingSize};
 use crate::util::Truncate;
 
+#[cfg(feature = "debug")]
+use crate::println;
+
 type DecodedValue = Array<FieldElement, U256>;
 
 // Algorithm 4 ByteEncode_d(F)
@@ -141,7 +144,11 @@ where
     type EncodedSize = D::EncodedPolynomialVectorSize;
 
     fn encode(&self) -> Array<u8, Self::EncodedSize> {
-        let polys = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+        let polys: Array<EncodedPolynomial<D>, K> = self.0.iter().map(|x| Encode::<D>::encode(x)).collect();
+
+        #[cfg(feature = "debug")]
+        polys.iter().for_each(|x| println!("{x:?}"));
+
         <D as VectorEncodingSize<K>>::flatten(polys)
     }
 

--- a/ml-kem/src/kemeleon.rs
+++ b/ml-kem/src/kemeleon.rs
@@ -10,7 +10,15 @@
 //!
 //! This has two practical uses, (1) making public keys sent over the wire
 //! indistinguishable from random bytes, and (2) streamlining the process of
-//! implementating the `hash2curve` interface for ml-kem.
+//! implementating a `hash2curve` like interface for ml-kem.
+//!
+//! The first-sample success probability is the probability that the
+//! highest-order bit after accumulation is 0.
+//! For ML-KEM-512 with parameters 𝑞 = 3329, 𝑛 = 256, 𝑘 = 2, this
+//! probability is ≈ 0.56, for ML-KEM-768 with 𝑘 = 3 it is ≈ 0.83, and
+//! for ML-KEM-1024 with 𝑘 = 4 and 𝑑𝑣 = 5, it is ≈ 0.62. The advantage
+//! of any adversary against public key uniformity is 0 since the output
+//! covers the entire output space uniformly.
 //!
 
 use hybrid_array::{

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -56,11 +56,11 @@ mod crypto;
 mod compress;
 
 cfg_if! {
-    if #[cfg(feature = "elligantt")] {
+    if #[cfg(feature = "kemeleon")] {
         /// Section 4.2.1. Conversion and Compression Algorithms
         ///  + Fully randomized encoding and decoding
-        mod elligantt;
-        use elligantt as encode;
+        mod kemeleon;
+        use kemeleon as encode;
     } else {
         /// Section 4.2.1. Conversion and Compression Algorithms, Encoding and decoding
         mod encode;

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -39,6 +39,8 @@
 //!
 //! [RFC 9180]: https://www.rfc-editor.org/info/rfc9180
 
+use cfg_if::cfg_if;
+
 /// The inevitable utility module
 mod util;
 
@@ -53,9 +55,17 @@ mod crypto;
 /// Section 4.2.1. Conversion and Compression Algorithms, Compression and decompression
 mod compress;
 
-/// Section 4.2.1. Conversion and Compression Algorithms, Encoding and decoding
-mod encode;
-
+cfg_if! {
+    if #[cfg(feature = "elligantt")] {
+        /// Section 4.2.1. Conversion and Compression Algorithms
+        ///  + Fully randomized encoding and decoding
+        mod elligantt;
+        use elligantt as encode;
+    } else {
+        /// Section 4.2.1. Conversion and Compression Algorithms, Encoding and decoding
+        mod encode;
+    }
+}
 /// Section 5. The K-PKE Component Scheme
 mod pke;
 

--- a/ml-kem/src/lib.rs
+++ b/ml-kem/src/lib.rs
@@ -86,6 +86,9 @@ use rand_core::CryptoRngCore;
 #[cfg(feature = "deterministic")]
 pub use util::B32;
 
+#[cfg(feature = "debug")]
+mod print;
+
 pub use param::{ArraySize, ParameterSet};
 
 /// An object that knows what size it is

--- a/ml-kem/src/print.rs
+++ b/ml-kem/src/print.rs
@@ -1,0 +1,50 @@
+// src/print.rs
+
+#![allow(unused)]
+
+use core::ffi::c_void;
+use core::fmt;
+
+extern "C" {
+    fn write(fildes: i32, buf: *const c_void, nbyte: usize);
+}
+
+pub fn write_string(s: &str) {
+    unsafe {
+        write(1, s.as_ptr() as *const c_void, s.len());
+    }
+}
+
+pub struct Writer;
+
+impl fmt::Write for Writer {
+    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        write_string(s);
+        Ok(())
+    }
+}
+
+pub fn print(args: fmt::Arguments) {
+    use fmt::Write;
+    Writer{}.write_fmt(args).unwrap();
+}
+
+/// macro standin for print when operating in no-std mode. For debug only
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        $crate::print::print(format_args!($($arg)*));
+    }}
+}
+
+/// macro standin for println when operating in no-std mode. For debug only
+#[macro_export]
+macro_rules! println {
+    () => {{
+        print!("\n");
+    }};
+
+    ($($arg:tt)*) => {{
+        $crate::print!("{}\n", format_args!($($arg)*));
+    }}
+}


### PR DESCRIPTION
This PR adds an encoding for ML-KEM encapsulation keys that makes the keys computationally indistinguishable from random.

**TODO:** more technical info about encoding scheme

Run tests with debug output:
```sh
cargo test -p ml-kem --features="debug" -- --nocapture --test-threads=1 elligantt
```